### PR TITLE
Custom API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Check out [this Github page](https://github.com/f/awesome-chatgpt-prompts) for s
 |Model|The ChatGPT model version that will be used to call the API. Note: you need access to the model to be able to use it.|_gpt-3.5-turbo_|
 |Prompt stop|Characters at the end of the sentence that will trigger the search| &#124;&#124; |
 |Default system prompt|The default keyword that will be used to lookup a System Prompt when no specific prompt has been given.| _normal_ |
+|Custom URL|Custom OpenAI Format API endpoint|_https://api.openai.com/v1/chat/completions_|
 
 # Backlog
 * Ability to take into account the context of the previous prompts.

--- a/SettingsTemplate.yaml
+++ b/SettingsTemplate.yaml
@@ -48,3 +48,9 @@ body:
         - warning
         - error
         - critical
+  - type: input
+    attributes:
+      name: api_endpoint
+      label: "API Endpoint:"
+      defaultValue: "https://api.openai.com/v1/chat/completions"
+      description: Custom OpenAI API endpoint

--- a/plugin.json
+++ b/plugin.json
@@ -8,5 +8,13 @@
     "Language": "python",
     "Website": "https://github.com/MichielvanBeers/Flow.Launcher.Plugin.ChatGPT",
     "IcoPath": "Images\\app.png",
-    "ExecuteFileName": "main.py"
+    "ExecuteFileName": "main.py",
+    "Settings": {
+        "api_endpoint": {
+            "type": "input",
+            "label": "API Endpoint",
+            "defaultValue": "https://api.openai.com/v1/chat/completions",
+            "description": "Custom OpenAI API endpoint"
+        }
+    }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "ChatGPT",
     "Description": "Plugin to use OpenAI's ChatGPT in Flow Launcher",
     "Author": "MichielvanBeers",
-    "Version": "1.2.2",
+    "Version": "1.3.0",
     "Language": "python",
     "Website": "https://github.com/MichielvanBeers/Flow.Launcher.Plugin.ChatGPT",
     "IcoPath": "Images\\app.png",


### PR DESCRIPTION
Add support for custom OpenAI API endpoint configuration.

* **SettingsTemplate.yaml**:
  - Add a new input field for `api_endpoint` with the label "API Endpoint:" and default value `https://api.openai.com/v1/chat/completions`.

* **plugin/main.py**:
  - Add an `api_endpoint` attribute to the `ChatGPT` class, initialized from settings.
  - Update the `send_prompt` method to use the `api_endpoint` attribute instead of the hardcoded endpoint.

* **plugin.json**:
  - Add the new `api_endpoint` setting with type, label, default value, and description.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MichielvanBeers/Flow.Launcher.Plugin.ChatGPT/pull/66?shareId=6701ed35-b308-41bf-b275-bc1cbb0171f3).